### PR TITLE
Adafruit-PlatformDetect version that for python3.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,12 @@ Here's the wiring diagram:
 
 ![Wiring Diagram](images/NanoI2CWiringDiagram.jpg)
 
+<h3>For user on python 3.6</h3>
+If you get "Error:future feature annotations is not defined",you specify the Adafruit-PlatformDetect version to 3.19.6.<br>
+Frist, remove the current version(anything > 3.19.6)<br>
+<blockquote>$sudo -H pip3 uninstall Adafruit-PlatformDetect</blockquote>
+Then install the version(3.19.6)<br>
+<blockquote>$sudo -H pip3 install Adafruit-PlatformDetect==3.19.6</blockquote>
+Now you install the adafruit-circuitpython-servokit :)<br>
 <h2>Releases</h2>
 Current Work in Progress

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's the wiring diagram:
 ![Wiring Diagram](images/NanoI2CWiringDiagram.jpg)
 
 <h3>For user on python 3.6</h3>
-If you get "Error:future feature annotations is not defined",you specify the Adafruit-PlatformDetect version to 3.19.6.<br>
+If you get "Error:future feature annotations is not defined",you may specify the Adafruit-PlatformDetect version to 3.19.6.<br>
 Frist, remove the current version(anything > 3.19.6)<br>
 <blockquote>$sudo -H pip3 uninstall Adafruit-PlatformDetect</blockquote>
 Then install the version(3.19.6)<br>

--- a/README.md
+++ b/README.md
@@ -34,5 +34,9 @@ Frist, remove the current version(anything > 3.19.6)<br>
 Then install the version(3.19.6)<br>
 <blockquote>$sudo -H pip3 install Adafruit-PlatformDetect==3.19.6</blockquote>
 Now you install the adafruit-circuitpython-servokit :)<br>
+If you get "NameError: name 'I2C' is not defined"<br>
+<blockquote>$sudo -H pip3 install adafruit-circuitpython-typing</blockquote>
+
 <h2>Releases</h2>
 Current Work in Progress
+

--- a/installServoKit.sh
+++ b/installServoKit.sh
@@ -13,6 +13,9 @@ sudo apt-get install python3-pip -y
 sudo -H pip3 install adafruit-circuitpython-servokit
 sudo -H pip3 install Adafruit-PlatformDetect==3.19.6
 sudo -H pip3 install Adafruit_CircuitPython_BusDevice==5.1.5
+# for NameError: name 'I2C' is not defined
+sudo -H pip3 install adafruit-circuitpython-typing
+
 echo ""
 echo "Adafruit CircuitPython ServoKit installed."
 echo "Please logoff/logon or reboot in order for I2C permissions to take effect."

--- a/installServoKit.sh
+++ b/installServoKit.sh
@@ -5,6 +5,11 @@ set -e
 sudo ./scripts/setPermissions.sh $USER
 # Then install servokit
 sudo apt-get install python3-pip -y
+# for jetson user on python 3.6.x
+# if you get a Adafruit-PlatformDetect > 3.19.6
+# you need to remove current version before install the working version
+# sudo -H pip3 uninstall Adafruit-PlatformDetect
+sudo -H pip3 install Adafruit-PlatformDetect==3.19.6
 sudo -H pip3 install adafruit-circuitpython-servokit
 echo ""
 echo "Adafruit CircuitPython ServoKit installed."

--- a/installServoKit.sh
+++ b/installServoKit.sh
@@ -10,9 +10,9 @@ sudo apt-get install python3-pip -y
 # you need to remove current version before install the working version
 # sudo -H pip3 uninstall Adafruit-PlatformDetect
 # sudo -H pip3 uninstall Adafruit_CircuitPython_BusDevice
+sudo -H pip3 install adafruit-circuitpython-servokit
 sudo -H pip3 install Adafruit-PlatformDetect==3.19.6
 sudo -H pip3 install Adafruit_CircuitPython_BusDevice==5.1.5
-sudo -H pip3 install adafruit-circuitpython-servokit
 echo ""
 echo "Adafruit CircuitPython ServoKit installed."
 echo "Please logoff/logon or reboot in order for I2C permissions to take effect."

--- a/installServoKit.sh
+++ b/installServoKit.sh
@@ -9,7 +9,9 @@ sudo apt-get install python3-pip -y
 # if you get a Adafruit-PlatformDetect > 3.19.6
 # you need to remove current version before install the working version
 # sudo -H pip3 uninstall Adafruit-PlatformDetect
+# sudo -H pip3 uninstall Adafruit_CircuitPython_BusDevice
 sudo -H pip3 install Adafruit-PlatformDetect==3.19.6
+sudo -H pip3 install Adafruit_CircuitPython_BusDevice==5.1.5
 sudo -H pip3 install adafruit-circuitpython-servokit
 echo ""
 echo "Adafruit CircuitPython ServoKit installed."


### PR DESCRIPTION
**Description**
Jetson on python 3.6 
If the Adafruit-PlatformDetect version >3.19.6, the error will appear in Adafruit-PlatformDetect   
- `Error: future feature annotations is not defined`   

this can be fix by removing the current version of Adafruit-PlatformDetect (anything after 3.19.6)
and install presivous version of Adafruit-PlatformDetect (anything <= 3.19.6)

**Change Made**
in [installServoKit.sh](https://github.com/JetsonHacksNano/ServoKit/compare/master...Drone-FYP2021-PolyU-EIE:master#diff-595bf69d37a84d9bae6c28e83bc03db5deeceae7df3a38636405f89b1a1d0e1f),  

- added line to [specify the version of SpecAdafruit-PlatformDetect to 3.19.6](https://github.com/JetsonHacksNano/ServoKit/commit/e080b919ebef7f09b92b19f9e6c706e33dd7c1d9)

updated readme to log this issues  

